### PR TITLE
Refactor assoc-to-fn assoc-to-fn-unbalanced.

### DIFF
--- a/src/clj_template/core.clj
+++ b/src/clj_template/core.clj
@@ -52,7 +52,7 @@
           (let [str-attrs#
                 (if (and (map? attrs#)
                          (not (empty? attrs#)))
-                  (str " " (gen-attributes attrs#) "/>")
+                  (str " " (gen-attributes attrs#) " />")
                   " />")]
             (str "<" ~markup-tag str-attrs#)))))
     tag-list)))


### PR DESCRIPTION
- src/clj-template/core.clj: use auto-gensym in syntax-quote to simplify the code.
